### PR TITLE
Enable LocalAI integration for report generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ This repository provides a small FastAPI application to generate corporate repor
 
 ## Uso
 
-Ejecute el servidor:
+Instale las dependencias y ejecute el servidor:
 
 ```bash
+pip install openai
 python server.py
 ```
 
@@ -18,3 +19,7 @@ Abra `http://localhost:8000` en su navegador para ingresar el título y contenid
 
 - El botón **Crear Informe** genera un archivo HTML de más de 30 páginas que puede imprimir como PDF.
 - El botón **Crear PPT** descarga un archivo `presentation.pptx` sencillo con una diapositiva que contiene el título y el contenido.
+
+## Uso con LocalAI
+
+Si dispone de una instancia de [LocalAI](https://github.com/go-skynet/LocalAI), defina la variable de entorno `OPENAI_BASE_URL` apuntando a su servidor (por ejemplo `http://localhost:8080/v1`). El programa utilizará esa URL para generar el texto de los informes.

--- a/server.py
+++ b/server.py
@@ -6,11 +6,19 @@ import openai
 import os
 
 async def generar_contenido_ia(prompt: str) -> str:
+    """Generate text using a model compatible with the OpenAI API.
+
+    The function reads the API key from ``OPENAI_API_KEY`` and optionally
+    a custom URL from ``OPENAI_BASE_URL`` (useful for LocalAI).
+    """
     openai.api_key = os.getenv("OPENAI_API_KEY")
+    base_url = os.getenv("OPENAI_BASE_URL")
+    if base_url:
+        openai.base_url = base_url
     response = await openai.ChatCompletion.acreate(
         model="gpt-3.5-turbo",
         messages=[{"role": "user", "content": prompt}],
-        max_tokens=500
+        max_tokens=500,
     )
     texto_generado = response.choices[0].message.content.strip()
     return texto_generado
@@ -67,8 +75,10 @@ def make_report_html(title: str, content: str) -> str:
 
 @app.post("/generate-report")
 async def generate_report(title: str = Form(...), content: str = Form(...)):
-    html = make_report_html(title, content)
-    return HTMLResponse(html, media_type='text/html')
+    """Create an HTML report using AI-generated content."""
+    ai_text = await generar_contenido_ia(content)
+    html = make_report_html(title, ai_text)
+    return HTMLResponse(html, media_type="text/html")
 
 # PPTX templates
 CONTENT_TYPES = """<?xml version='1.0' encoding='UTF-8'?>


### PR DESCRIPTION
## Summary
- allow specifying `OPENAI_BASE_URL` to work with LocalAI
- generate report text using AI instead of raw content
- document LocalAI usage in README

## Testing
- `python -m py_compile server.py`

------
https://chatgpt.com/codex/tasks/task_e_684bb27e96b88326bb46238ecbd36e71